### PR TITLE
Faster multi-tag build and documentation update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,5 +45,5 @@ jobs:
           docker swarm init
           docker version
           docker info
-          docker pull quay.io/testcontainers/ryuk:0.2.2
+          docker pull testcontainers/ryuk:0.3.3
           mvn clean install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,4 +46,4 @@ jobs:
           docker version
           docker info
           docker pull testcontainers/ryuk:0.3.3
-          mvn clean install
+          mvn -B clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install: true # This runs the "true" command in the install phase; thus skipping
 script:
   - |
     if [[ "$TRAVIS_BRANCH" == master && "$TRAVIS_PULL_REQUEST" == false && "$TRAVIS_JDK_VERSION" == "openjdk8" ]]
-    then mvn deploy -s travis-settings.xml
-    else mvn verify
+    then mvn -B deploy -s travis-settings.xml
+    else mvn -B verify
     fi
 
 cache:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For more examples, see the [integration test](./plugin/src/it) directory.
 
 In particular, the [advanced](./plugin/src/it/advanced) test showcases a
 full service consisting of two micro-services that are integration
-tested using `helios-testing`.
+tested.
 
 This configures the actual plugin to build your image with `mvn
 package` and push it with `mvn deploy`.  Of course you can also say
@@ -52,7 +52,7 @@ package` and push it with `mvn deploy`.  Of course you can also say
 
 ```xml
 <plugin>
-  <groupId>com.spotify</groupId>
+  <groupId>com.xenoamess.docker</groupId>
   <artifactId>dockerfile-maven-plugin</artifactId>
   <version>${dockerfile-maven-version}</version>
   <executions>
@@ -132,7 +132,7 @@ built and pushed at the correct times.
 ### Depend on Docker images of other services
 
 You can depend on the Docker information of another project, because
-this plugin attaches project metadata when it builds Docker images.
+this plugin attaches project metadata (Docker Info JAR) when it builds Docker images.
 Simply add this information to any project:
 
 ```xml

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -6,8 +6,11 @@ Since version 1.3.0, the plugin will automatically use any configuration in
 your `~/.dockercfg` or `~/.docker/config.json` file when pulling, pushing, or
 building images to private registries.
 
-Additionally the plugin will enable support for Google Container Registry if it
-is able to successfully load [Google's "Application Default Credentials"][ADC].
+### Google Container Registry Support
+
+Additionally the plugin supports for Google Container Registry if it
+is enabled (see below) and is able to successfully load 
+[Google's "Application Default Credentials"][ADC].
 The plugin will also load Google credentials from the file pointed to by the
 environment variable `DOCKER_GOOGLE_CREDENTIALS` if it is defined. Since GCR
 authentication requires retrieving short-lived access codes for the given
@@ -27,6 +30,14 @@ or [create a service account][service-acct] instead.
 
 [app-def-login]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 [service-acct]: https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account
+
+And also enable Google Container Registry for authentication in the configuration:
+
+```xml
+<configuration>
+  <googleContainerRegistryEnabled>true</googleContainerRegistryEnabled>
+</configuration>
+```
 
 ## Authenticating with maven settings.xml
 
@@ -68,7 +79,7 @@ Just add configuration similar to:
 
 ```xml
  <plugin>
-    <groupId>com.spotify</groupId>
+    <groupId>com.xenoamess.docker</groupId>
     <artifactId>dockerfile-maven-plugin</artifactId>
     <version>${version}</version>
     <configuration>
@@ -84,7 +95,7 @@ Just add configuration similar to:
 or simpler,
 ```xml
  <plugin>
-    <groupId>com.spotify</groupId>
+    <groupId>com.xenoamess.docker</groupId>
     <artifactId>dockerfile-maven-plugin</artifactId>
     <version>${version}</version>
     <configuration>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,8 +9,9 @@ Goals available for this plugin:
 | `dockerfile:build` | Builds a Docker image from a Dockerfile. | package |
 | `dockerfile:tag` | Tags a Docker image. | package |
 | `dockerfile:push` | Pushes a Docker image to a repository. | deploy |
+| `dockerfile:remove` | Removes a Docker image from a repository. | none |
 
-### Skip Docker Goals Bound to Maven Phases
+### Skip Docker Goals
 
 You can pass options to maven to disable the docker goals.
 
@@ -18,15 +19,45 @@ You can pass options to maven to disable the docker goals.
 | ------------- | -------------------------- | ------------- |
 | `dockerfile.skip` | Disables the entire dockerfile plugin; all goals become no-ops. | false |
 | `dockerfile.build.skip` | Disables the build goal; it becomes a no-op. | false |
-| `dockerfile.tag.skip` | Disables the tag goal; it becomes a no-op. | false |
 | `dockerfile.push.skip` | Disables the push goal; it becomes a no-op. | false |
+| `dockerfile.remove.skip` | Disables the remove goal; it becomes a no-op. | false |
+| `dockerfile.tag.skip` | Disables the tag goal; it becomes a no-op. | false |
 
 For example, to skip the entire dockerfile plugin:
 ```
 mvn clean package -Ddockerfile.skip
 ```
 
+### Ignore failures in Docker Goals
+
+You can pass options to maven to disable the docker goals.
+
+| Maven Option  | What Does it Do?           | Default Value |
+| ------------- | -------------------------- | ------------- |
+| `dockerfile.build.failure.ignore` | Do not fail build when building image fails | false |
+| `dockerfile.push.failure.ignore` | Do not fail build when pushing image fails | false |
+| `dockerfile.remove.failure.ignore` | Do not fail build when removing image fails | false |
+| `dockerfile.tag.failure.ignore` | Do not fail build when tagging image fails | false |
+
+For example, to ignore failures when building an image:
+```
+mvn clean package -Ddockerfile.build.failure.ignore
+```
+
+
 ## Configuration
+
+### General options
+
+| Maven Option  | What Does it Do?           | Required | Default Value |
+| ------------- | -------------------------- | -------- | ------------- |
+| `dockerfile.googleContainerRegistryEnabled` | Enables Google Container Registry authentication support. | no | false |
+| `dockerfile.password` | Password for connecting to the Docker repository | no | none |
+| `dockerfile.retryCount` | Certain Docker operations can fail due to mysterious Docker daemon conditions. Sometimes it might be worth it to just retry operations until they succeed.  This parameter controls how many times operations should be retried before they fail. By default, an extra attempt (so up to two attempts) is made before failing. | no | 1 |
+| `dockerfile.username` | Username for connecting to the Docker repository | no | none |
+| `dockerfile.useProxy` | Allows connecting to Docker Daemon using HTTP proxy if set | no | false |
+| `dockerfile.verbose` | Output a verbose log when performing various operations. | no | false |
+
 
 ### Build Phase
 
@@ -35,8 +66,23 @@ mvn clean package -Ddockerfile.skip
 | `dockerfile.contextDirectory` | Directory containing the Dockerfile to build. | yes | none |
 | `dockerfile.repository` | The repository to name the built image | no | none |
 | `dockerfile.tag` | The tag to apply when building the Dockerfile, which is appended to the repository. | no | latest |
+| `dockerfile.tags` | The tags to apply when building the Dockerfile, which is appended to the repository. If `dockerfile.tags` is used then `dockerfile.tag` will be ignored. The first tag is used if and when writing a docker-info jar. | no | latest |
 | `dockerfile.build.pullNewerImage` | Updates base images automatically. | no | true |
 | `dockerfile.build.noCache` | Do not use cache when building the image. | no | false |
 | `dockerfile.build.cacheFrom` | Docker image used as cache-from. Pulled in advance if not exist locally or `pullNewerImage` is `false` | no | none |
 | `dockerfile.buildArgs` | Custom build arguments. | no | none |
 | `dockerfile.build.squash` | Squash newly built layers into a single new layer (experimental API 1.25+). | no | false |
+| `dockerfile.force` | Force the tagging even if the tag is already assigned to another image. | no | true |
+| `dockerfile.skipDockerInfo` | Skip creating a Docker info JAR artifact that could be used to depend on an image created by this plugin in another project/module. | no 
+| `dockerfile.classifier` | The classifier to apply to the created Docker info JAR. | no | docker-info |
+| `dockerfile.finalName` | The name of the generated Docker info JAR. | no | `${project.build.finalName}` |
+| `dockerfile.forceCreation` | Require the jar plugin to build a new Docker info JAR even if none of the contents appear to have changed. By default, this plugin looks to see if the output jar exists and inputs have not changed. If these conditions are true, the plugin skips creation of the jar. This does not work when other plugins, like the maven-shade-plugin, are configured to post-process the jar. This plugin can not detect the post-processing, and so leaves the post-processed jar in place. This can lead to failures when those plugins do not expect to find their own output as an input. Set this parameter to `true` to avoid these problems by forcing this plugin to recreate the jar every time. | no | false |
+
+
+### Tag Phase
+
+| Maven Option  | What Does it Do?           | Required | Default Value |
+| ------------- | -------------------------- | -------- | ------------- |
+| `dockerfile.force` | Force the tagging even if the tag is already assigned to another image. | no | true |
+| `dockerfile.repository` | The repository to name the built image | no | none |
+| `dockerfile.tag` | The tag to apply when building the Dockerfile, which is appended to the repository. | no | latest |

--- a/plugin/src/it/advanced/frontend/pom.xml
+++ b/plugin/src/it/advanced/frontend/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>31.0.1-jre</version>
     </dependency>
 
     <dependency>
@@ -75,17 +75,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.spotify</groupId>
-      <artifactId>helios-testing</artifactId>
-      <version>0.9.71</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.9.1</version>
+      <version>1.16.3</version>
       <scope>test</scope>
     </dependency>
+    
   </dependencies>
 
   <build>

--- a/plugin/src/it/advanced/frontend/src/test/java/com/spotify/it/frontend/MainIT.java
+++ b/plugin/src/it/advanced/frontend/src/test/java/com/spotify/it/frontend/MainIT.java
@@ -96,7 +96,7 @@ public class MainIT {
   private GenericContainer createFrontend(final Network network) {
     final String image;
     try {
-      image = Files.readFirstLine(new File("target/docker/image-name"), Charsets.UTF_8);
+      image = Files.asCharSource(new File("target/docker/image-name"), Charsets.UTF_8).readFirstLine();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/plugin/src/it/advanced/pom.xml
+++ b/plugin/src/it/advanced/pom.xml
@@ -22,6 +22,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>com.xenoamess.it</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
 
   <groupId>com.spotify.it</groupId>
   <artifactId>advanced</artifactId>

--- a/plugin/src/it/build-into-multiple-tags/build-and-tag/Dockerfile
+++ b/plugin/src/it/build-into-multiple-tags/build-and-tag/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+LABEL AUTHOR G. Calis
+# make image different from others
+COPY pom.xml .

--- a/plugin/src/it/build-into-multiple-tags/build-and-tag/pom.xml
+++ b/plugin/src/it/build-into-multiple-tags/build-and-tag/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2016 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify.it</groupId>
+    <artifactId>build-into-multiple-tags</artifactId>
+    <version>1.2.3-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>build-and-tag</artifactId>
+
+  <description>The Dockerfile is built into a repository with multiple custom tags</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <repository>test/build-into-multiple-tags</repository>
+              <tags>
+                <tag>${project.version}</tag>
+                <tag>latest</tag>
+                <tag>third</tag>
+              </tags>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin/src/it/build-into-multiple-tags/build-and-tag/verify.groovy
+++ b/plugin/src/it/build-into-multiple-tags/build-and-tag/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * -/-/-
+ * Dockerfile Maven Plugin
+ * %%
+ * Copyright (C) 2015 - 2016 Spotify AB
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -\-\-
+ */
+File imageIdFile = new File(basedir, "target/docker/image-id")
+assert imageIdFile.isFile()
+
+File repositoryFile = new File(basedir, "target/docker/repository")
+assert repositoryFile.text == "test/build-into-multiple-tags\n"
+
+File tagFile = new File(basedir, "target/docker/tag")
+assert tagFile.text == "1.2.3-SNAPSHOT\n"
+
+File imageNameFile = new File(basedir, "target/docker/image-name")
+assert imageNameFile.text == "test/build-into-multiple-tags:1.2.3-SNAPSHOT\n"

--- a/plugin/src/it/build-into-multiple-tags/pom.xml
+++ b/plugin/src/it/build-into-multiple-tags/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2016 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>com.xenoamess.it</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>com.spotify.it</groupId>
+  <artifactId>build-into-multiple-tags</artifactId>
+  <version>1.2.3-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <description>The Dockerfile is built into a repository with multiple custom tags</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  
+  <modules>
+    <module>build-and-tag</module>
+    <module>verify-tags</module>
+  </modules>
+  
+</project>

--- a/plugin/src/it/build-into-multiple-tags/verify-tags/pom.xml
+++ b/plugin/src/it/build-into-multiple-tags/verify-tags/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2016 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify.it</groupId>
+    <artifactId>build-into-multiple-tags</artifactId>
+    <version>1.2.3-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>verify-tags</artifactId>
+
+  <description>Verifies both tags are set for image build in the other module.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.xenoamess.docker</groupId>
+      <artifactId>docker-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin/src/it/build-into-multiple-tags/verify-tags/src/test/java/com/spotify/it/verify/VerifyMultipleTagsIT.java
+++ b/plugin/src/it/build-into-multiple-tags/verify-tags/src/test/java/com/spotify/it/verify/VerifyMultipleTagsIT.java
@@ -1,0 +1,42 @@
+package com.spotify.it.verify;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient.ListImagesParam;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.Image;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class VerifyMultipleTagsIT {
+  
+  private DefaultDockerClient dockerCLient;
+  private static final String IMAGE_NAME = "test/build-into-multiple-tags";
+  
+  @Before
+  public void setup() throws Exception {
+    final DefaultDockerClient.Builder builder = DefaultDockerClient.fromEnv();
+    builder.readTimeoutMillis(5000);
+    dockerCLient = builder.build();
+  }
+  
+  @Test
+  public void testVerifyTags() throws DockerException, InterruptedException {
+    // final List<Image> imagesByName = dockerCLient.listImages(ListImagesParam.create("reference", IMAGE_NAME + "*:*") );
+    final List<String> tags;
+    final List<Image> images = dockerCLient.listImages(ListImagesParam.filter("reference", IMAGE_NAME + ":*") );
+    assertThat(images.size(), equalTo(1));
+
+    tags = images.get(0).repoTags();
+    assertThat(tags.size(), equalTo(3));
+    assertTrue(tags.containsAll(Arrays.asList(IMAGE_NAME + ":1.2.3-SNAPSHOT", IMAGE_NAME + ":latest", IMAGE_NAME + ":third")));
+  }
+  
+}

--- a/plugin/src/it/pom.xml
+++ b/plugin/src/it/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.xenoamess.it</groupId>
+  <artifactId>it-parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.5</version>
+                </requireMavenVersion>
+              </rules>    
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.0</version>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/plugin/src/it/pom.xml
+++ b/plugin/src/it/pom.xml
@@ -6,7 +6,21 @@
   <artifactId>it-parent</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-
+  
+  <name>it-parent</name>
+  <description>Parent pom for managing plugins used in integration tests</description>
+  
+  <dependencyManagement>  
+    <dependencies>
+      <dependency>
+        <groupId>com.xenoamess.docker</groupId>
+        <artifactId>docker-client</artifactId>
+        <version>8.17.2</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
   <build>
     <plugins>
       <plugin>
@@ -41,8 +55,21 @@
             <target>1.8</target>
           </configuration>
         </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>3.0.0-M5</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+    
   </build>
 
 </project>

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
@@ -23,7 +23,6 @@ package com.spotify.plugin.dockerfile;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
@@ -300,7 +299,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     }
 
     try {
-      Files.write(value + "\n", metadataFile, Charsets.UTF_8);
+      Files.asCharSink(metadataFile, Charsets.UTF_8).write(value + "\n");
     } catch (IOException e) {
       final String message =
           MessageFormat.format("Could not write {0} file at {1}", metadata.getFriendlyName(),
@@ -417,7 +416,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     }
 
     try {
-      return Files.readFirstLine(metadataFile, Charsets.UTF_8);
+      return Files.asCharSource(metadataFile, Charsets.UTF_8).readFirstLine();
     } catch (IOException e) {
       final String message =
           MessageFormat.format("Could not read {0} file at {1}", metadata.getFileName(),

--- a/plugin/src/test/java/com/spotify/plugin/dockerfile/TestRepoNameValidation.java
+++ b/plugin/src/test/java/com/spotify/plugin/dockerfile/TestRepoNameValidation.java
@@ -25,10 +25,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class TestRepoNameValidation {
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testSuccess() throws MojoFailureException {


### PR DESCRIPTION
Hi, I hope you're accepting pull requests, because I like what you're doing and would like to contribute.
If you'd rather have this PR split into more parts or have other remarks, please let me know.

Two major changes, one functional and the other documentation:
1. When building images with multiple tags, only build the image once and then apply tags. Now the image is build multiple times, which wastes time and resources.
2. Added integration test to verify building with multiple tags.
3. Update documentation: new tags configuration, updated groupId, added missing configuration properties, documented enabling Google Container Registry authentication. 
(I planned on using a separate PR for the documentation update, but some properties for the mult-tag build )

Additionally, some minor changes:
1. Fixed advanced-frontend integration test that consistently failed in my local (ubuntu/WSL) environment (updated some dependencies and testcontainers docker image).
2. Replaced/removed deprecated API uses.
3. Made Maven build less verbose by enabling batch mode (-B): now ~5k lines instead of ~25k. Removes non-essential logging like download progress, but keeps all interesting logging.
4. Created parent-pom for integration tests to pin some plugin&dependecy versions, thus removing some warnings from the build and improving build stability.
