### PR TITLE
Fix build: fixed advanced integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,4 +46,4 @@ jobs:
           docker version
           docker info
           docker pull testcontainers/ryuk:0.3.3
-          mvn -B clean install
+          mvn --batch-mode clean install "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -218,6 +218,9 @@
           <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
           <settingsFile>src/it/settings.xml</settingsFile>
           <streamLogs>true</streamLogs>
+          <properties>
+            <org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>warn</org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>
+          </properties>
           <goals>
             <goal>clean</goal>
             <goal>verify</goal>

--- a/plugin/src/it/advanced/backend/Dockerfile
+++ b/plugin/src/it/advanced/backend/Dockerfile
@@ -1,6 +1,8 @@
-FROM java
-MAINTAINER David Flemström <dflemstr@spotify.com>
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/backend/backend.jar"]
+FROM eclipse-temurin:11-jre-alpine
 
-ADD target/lib /usr/share/backend/lib
-ADD target/backend.jar /usr/share/backend/backend.jar
+LABEL MAINTAINER="David Flemström <dflemstr@spotify.com>"
+
+COPY target/lib /usr/share/backend/lib
+COPY target/backend.jar /usr/share/backend/backend.jar
+
+ENTRYPOINT ["java", "-jar", "/usr/share/backend/backend.jar"]

--- a/plugin/src/it/advanced/frontend/Dockerfile
+++ b/plugin/src/it/advanced/frontend/Dockerfile
@@ -1,6 +1,8 @@
-FROM java
-MAINTAINER David Flemström <dflemstr@spotify.com>
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/frontend/frontend.jar"]
+FROM eclipse-temurin:11-jre-alpine
 
-ADD target/lib /usr/share/frontend/lib
-ADD target/frontend.jar /usr/share/frontend/frontend.jar
+LABEL MAINTAINER="David Flemström <dflemstr@spotify.com>"
+
+COPY target/lib /usr/share/frontend/lib
+COPY target/frontend.jar /usr/share/frontend/frontend.jar
+
+ENTRYPOINT ["java", "-jar", "/usr/share/frontend/frontend.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,6 @@
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0</version>
-        <configuration>
-          <updateReleaseInfo>true</updateReleaseInfo>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Fixes the build by using other java docker images in the `advanced` integration tests. 
The used images are no longer available.

Also some minor tweaks to clean up a build warning (obsolete config option) and reduce the logging (by about 50%) by not printing all the output for downloading artifacts during the build.